### PR TITLE
Fixed missing import of MobFoxNativeAd.h

### DIFF
--- a/Core/MobFox.h
+++ b/Core/MobFox.h
@@ -6,3 +6,4 @@
 #import "MobFoxInterstitialViewController.h"
 #import "MobFoxVASTRequestManager.h"
 #import "MobFoxInlineVideoAd.h"
+#import "MobFoxNativeAd.h"


### PR DESCRIPTION
The MobFox.h file was missing the MobFoxNativeAd.h import. This caused issues when working with Swift saying the ViewController cannot conform to protocol 'MobFoxNativeAdDelegate' because it has requirements that cannot be satisfied